### PR TITLE
Remove discourse-staff-notes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,10 +30,6 @@
 	path = plugins/discourse-affiliate
 	url = https://github.com/discourse/discourse-affiliate.git
 	branch = main
-[submodule "plugins/discourse-staff-notes"]
-	path = plugins/discourse-staff-notes
-	url = https://github.com/discourse/discourse-staff-notes.git
-	branch = main
 [submodule "plugins/discourse-adplugin"]
 	path = plugins/discourse-adplugin
 	url = https://github.com/discourse/discourse-adplugin.git


### PR DESCRIPTION
It was renamed to discourse-user-notes and it's already in the repo