### PR TITLE
Add discourse-openclaw

### DIFF
--- a/third-party.txt
+++ b/third-party.txt
@@ -131,6 +131,7 @@ pfaffman/discourse-doi-resolver
 phw/discourse-musicbrainz-onebox
 pmusaraj/discourse-onesignal
 PoloGT/abbreviation-discourse-plugin
+pranciskus/discourse-openclaw
 procourse/discourse-full-screen-videos-plugin
 procourse/discourse-mlm-daily-summary
 procourse/procourse-static-pages


### PR DESCRIPTION
## Summary
- Adds [discourse-openclaw](https://github.com/pranciskus/discourse-openclaw) to the third-party plugins list
- discourse-openclaw is an OpenClaw plugin for Discourse forum integration, providing 12 API tools (9 read + 3 write) for AI agents to interact with Discourse forums

## Test plan
- [ ] Verify the entry is in the correct alphabetical position in `third-party.txt`
- [ ] Verify the plugin repository URL is valid and accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)