### PR TITLE
Add discourse-proxytracer

### DIFF
--- a/third-party.txt
+++ b/third-party.txt
@@ -135,6 +135,7 @@ pranciskus/discourse-openclaw
 procourse/discourse-full-screen-videos-plugin
 procourse/discourse-mlm-daily-summary
 procourse/procourse-static-pages
+proxytracer/discourse-proxytracer
 rcfox/Discourse-Webhooks
 reallyreally/discourse-mailgun
 Regalijan/discourse-codeberg-auth


### PR DESCRIPTION
- **Plugin description**: Automatically block VPN and proxy traffic during user registration, login, and/or globally in Discourse using the ProxyTracer API. 
- **Github repo**: https://github.com/proxytracer/discourse-proxytracer
- **Meta Discourse post**: https://meta.discourse.org/t/proxytracer-vpn-proxy-blocker/399958